### PR TITLE
Always determine the user's config path at runtime

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,7 +40,7 @@ void processArguments(int argc, char **argv)
 
             case 'i':
                 cout << prefix << "Import feeds from: " << optarg << endl;
-                imported = opml::import(optarg, FEED_CONFIG_PATH);
+                imported = opml::import(optarg, getFeedConfigPath());
                 cout << prefix << imported << " feed(s) was imported" << endl;
                 break;
 


### PR DESCRIPTION
Use getFeedConfigPath() for the "-i" option in processArguments(), the
same as is done for the "-e" option, and in main(). Avoids errors or
confusion when the runtime environment is not the same as the build
environment.