### PR TITLE
Add $article_width variable for renderText option

### DIFF
--- a/doc/neix.1
+++ b/doc/neix.1
@@ -82,8 +82,10 @@ OPTION@Value
 _
 dateFormat@String which represents the format for the feed date.
 locale@Here you can set the locale for your language.
-openCommand@Here you can set which programm should be used to open the article link.
-renderText@You can set how the text should be formatted. [OPTIONAL]
+openCommand@Here you can set which program should be used to open the article link.
+renderText@You can set how the text should be formatted.
+@`$article_width` will be replaced with the article frame width,
+@which can be useful to limit width of dumped output [OPTIONAL]
 .TE
 .RE
 

--- a/include/helper/TextConverter.h
+++ b/include/helper/TextConverter.h
@@ -21,7 +21,7 @@ namespace neix
     class TextConverter 
     {
     public:
-        TextConverter(string t, string c = string());
+        TextConverter(string t, int a_w, string c = string());
         ~TextConverter();
 
         string stripHtml();
@@ -31,7 +31,7 @@ namespace neix
     private:
         string text;
         string cmd;
-
+        int article_width;
         string _buildFullRenderCommand(const string& rawFilePath, 
             const string& renderedFilePath);
         bool _prepareRawText(const string& rawFilePath, const string text);

--- a/include/helper/TextConverter.h
+++ b/include/helper/TextConverter.h
@@ -21,7 +21,7 @@ namespace neix
     class TextConverter 
     {
     public:
-        TextConverter(string t, int a_w, string c = string());
+        TextConverter(string t, string c = string(), int a_w = 0);
         ~TextConverter();
 
         string stripHtml();

--- a/include/helper/helper.h
+++ b/include/helper/helper.h
@@ -30,5 +30,5 @@ string getMainConfigPath();
 string getFeedConfigPath(string configName = "");
 bool configFilesExists();
 bool copyDefaultConfigFiles();
-
+string replaceString(string str, const string& replace, const string& with);
 #endif //neix_HELPER_H

--- a/src/application/Application.cpp
+++ b/src/application/Application.cpp
@@ -473,7 +473,7 @@ void Application::openArticle()
 
     if (strlen(entry->description) > 0)
     {
-        TextConverter tc(entry->description, length, this->renderCommand);
+        TextConverter tc(entry->description, this->renderCommand, length);
         this->rw.pushContent(tc.execCmd());
     }
 

--- a/src/application/Application.cpp
+++ b/src/application/Application.cpp
@@ -473,7 +473,7 @@ void Application::openArticle()
 
     if (strlen(entry->description) > 0)
     {
-        TextConverter tc(entry->description, this->renderCommand);
+        TextConverter tc(entry->description, length, this->renderCommand);
         this->rw.pushContent(tc.execCmd());
     }
 

--- a/src/helper/TextConverter.cpp
+++ b/src/helper/TextConverter.cpp
@@ -22,11 +22,12 @@ using namespace neix;
 /**
  * Constructor
  */
-TextConverter::TextConverter(string t, string c)
+TextConverter::TextConverter(string t, int a_w, string c)
 {
     this->text = move(t);
     this->cmd = move(c);
     this->cmdExecuted = false;
+    this->article_width = a_w;
 }
 
 
@@ -91,7 +92,7 @@ string TextConverter::execCmd()
 string TextConverter::_buildFullRenderCommand(const string& rawFilePath, 
     const string& renderedFilePath)
 {
-    string renderCmd = this->cmd;
+    string renderCmd = replaceString(this->cmd, "$article_width", to_string(this->article_width));
     renderCmd += " ";
     renderCmd += rawFilePath;
     renderCmd += " > ";

--- a/src/helper/TextConverter.cpp
+++ b/src/helper/TextConverter.cpp
@@ -22,7 +22,7 @@ using namespace neix;
 /**
  * Constructor
  */
-TextConverter::TextConverter(string t, int a_w, string c)
+TextConverter::TextConverter(string t, string c, int a_w)
 {
     this->text = move(t);
     this->cmd = move(c);

--- a/src/helper/helper.cpp
+++ b/src/helper/helper.cpp
@@ -143,3 +143,17 @@ bool copyDefaultConfigFiles()
 
     return true;
 }
+
+/**
+ * Replace all occurrences of substr "r" with "s"
+ */
+string replaceString(string str, const string& replace, const string& with) {
+    if(!replace.empty()) {
+        std::size_t pos = 0;
+        while ((pos = str.find(replace, pos)) != std::string::npos) {
+            str.replace(pos, replace.length(), with);
+            pos += with.length();
+        }
+    }
+    return str;
+}

--- a/test/helper/TextConverter.cpp
+++ b/test/helper/TextConverter.cpp
@@ -56,4 +56,31 @@ namespace {
         txt = tcon.execCmd();
         EXPECT_STREQ(txt.c_str(), "Hello World again."); 
     }
+
+    TEST(TextConverter, execCmd_article_width)
+    {
+        TextConverter tc("Unused", "f() { echo \"The article width is $article_width\" } && f", 3);
+        string txt = tc.execCmd();
+       
+        string expected = "The article width is 3";
+        if (!tc.cmdExecuted)
+        {
+            expected = "Unused"; 
+        }
+        EXPECT_STREQ(txt.c_str(), expected.c_str());
+        
+        TextConverter tc2("Unused", "f() { echo \"The article width is $article_width\" } && f");
+        string txt2 = tc2.execCmd();
+       
+        string expected2 = "The article width is 0";
+        if (!tc2.cmdExecuted)
+        {
+            expected2 = "Unused"; 
+        }
+        EXPECT_STREQ(txt2.c_str(), expected2.c_str());
+
+        TextConverter tcon("Hello <b>World</b> again.");
+        txt = tcon.execCmd();
+        EXPECT_STREQ(txt.c_str(), "Hello World again.");
+    }
 }


### PR DESCRIPTION
Add runtime var to send the actual width of the article to renderText command by text replacement

This allows renderText to have $article_width anywhere in the
command which will be replaced by the width of the article display
window.

Code Changes-
- Add article_width variable to TextConverter
- Add function helper.h#replaceString
- Change TextConverter to replace instances of $article_width with val

Other Changes-
- Change doc/neix.1 to reflect changes in options

Fixes #21 