### PR TITLE
Optimize for termux

### DIFF
--- a/include/application/Application.h
+++ b/include/application/Application.h
@@ -48,9 +48,10 @@ namespace neix
         int quit;
         int c;
 
-        int windowHeight;
         int feedWindowWidth;
+        int feedWindowHeight;
         int articleWindowWidth;
+        int articleWindowHeight;
 
         void initChoices();
         void printVersion();

--- a/include/config.h
+++ b/include/config.h
@@ -17,6 +17,7 @@
 #define KEY_K 107
 #define KEY_O 111
 #define KEY_Q 113
+#define KEY_R 114
 
 #define KEY_UPPER_J 74
 #define KEY_UPPER_K 75

--- a/src/application/Application.cpp
+++ b/src/application/Application.cpp
@@ -20,6 +20,8 @@
 #include "application/ApplicationWindow.h"
 #include "feed/Feeds.h"
 
+#define REFLOW_LIMIT 60
+
 using namespace std;
 using namespace neix;
 
@@ -72,7 +74,7 @@ void Application::initChoices()
  */
 void Application::createFeedWindow()
 {
-    if (COLS > 60)
+    if (COLS > REFLOW_LIMIT)
     {
         this->feedWindowWidth = (int) (COLS / 3);
         this->feedWindowHeight = LINES-4;
@@ -92,7 +94,7 @@ void Application::createFeedWindow()
  */
 void Application::createArticleWindow()
 {
-    if (COLS > 60)
+    if (COLS > REFLOW_LIMIT)
     {
         this->articleWindowWidth = (int) (COLS * 2 / 3);
         this->articleWindowHeight = LINES-4;
@@ -105,7 +107,7 @@ void Application::createArticleWindow()
 
     this->aw.setDimensions(this->articleWindowHeight, this->articleWindowWidth);
 
-    if (COLS > 60)
+    if (COLS > REFLOW_LIMIT)
         this->aw.setPosition(2, this->feedWindowWidth);
     else
         this->aw.setPosition(this->feedWindowHeight+2, 0);
@@ -117,7 +119,7 @@ void Application::createArticleWindow()
 void Application::createReadWindow()
 {
     this->rw.setDimensions(this->articleWindowHeight, this->articleWindowWidth);
-    if (COLS > 60)
+    if (COLS > REFLOW_LIMIT)
     {
         this->rw.setPosition(2, this->feedWindowWidth);
     }

--- a/src/application/Application.cpp
+++ b/src/application/Application.cpp
@@ -116,15 +116,18 @@ void Application::resize()
     this->printVersion();
     this->printControlHints();
 
+    this->windowHeight = LINES - 4;
     this->createFeedWindow();
     this->createArticleWindow();
     this->createReadWindow();
+    this->fillWindowsWithContent();
     this->printWindows();
 
     if (this->reading)
     {
         this->openArticle();
     }
+    refresh();
 }
 
 
@@ -145,7 +148,10 @@ void Application::printVersion()
 void Application::printControlHints()
 {
     attron(A_REVERSE);
-    mvprintw(LINES - 2, 0, " q:Quit/Close | ENTER:Open | o:Open Browser | j/J:Down | k/K:Up ");
+    if (COLS > 74)
+        mvprintw(LINES - 2, 0, " q:Quit/Close | ENTER:Open | o:Open Browser | j/J/PGDN:Down | k/K/PGUP:Up ");
+    else
+        mvprintw(LINES - 2, 0, " q | ENTER | o | j/J/PGDN | k/K/PGUP ");
     attroff(A_REVERSE);
 }
 
@@ -170,6 +176,7 @@ void Application::show()
         int articleCount = feeds->getFeed(this->choice)->articleCount;
         switch (this->c)
         {
+            case KEY_R:
             case KEY_RESIZE:
                 this->resize();
                 break;
@@ -206,6 +213,7 @@ void Application::show()
                 }
                 break;
 
+            case KEY_PPAGE:
             case KEY_UPPER_K:
 				if (this->reading)
 				{
@@ -214,7 +222,7 @@ void Application::show()
 
                 this->articleChoice = 0;
                 this->fw.decreaseHighlight();
-		this->fw.scrollUp();
+                this->fw.scrollUp();
                 this->fw.update();
                 this->choice = this->decreaseChoice(this->choice, feedCount);
 
@@ -224,6 +232,7 @@ void Application::show()
                 this->aw.update();
                 break;
 
+            case KEY_NPAGE:
             case KEY_UPPER_J:
 				if (this->reading)
 				{
@@ -232,7 +241,7 @@ void Application::show()
 
                 this->articleChoice = 0;
                 this->fw.increaseHighlight();
-		this->fw.scrollDown();
+                this->fw.scrollDown();
                 this->fw.update();
                 this->choice = this->increaseChoice(this->choice, feedCount);
 

--- a/src/application/Application.cpp
+++ b/src/application/Application.cpp
@@ -255,6 +255,7 @@ void Application::show()
                 this->openArticleLink();
                 break;
 
+            case KEY_RIGHT:
             case ENTER:
                 this->aw.hide();
                 this->openArticle();
@@ -264,6 +265,7 @@ void Application::show()
                 this->fw.update();
                 break;
 
+            case KEY_LEFT:
             case KEY_Q:
                 if (this->reading)
                 {

--- a/src/application/Application.cpp
+++ b/src/application/Application.cpp
@@ -127,7 +127,6 @@ void Application::resize()
     {
         this->openArticle();
     }
-    refresh();
 }
 
 
@@ -148,10 +147,11 @@ void Application::printVersion()
 void Application::printControlHints()
 {
     attron(A_REVERSE);
-    if (COLS > 74)
-        mvprintw(LINES - 2, 0, " q:Quit/Close | ENTER:Open | o:Open Browser | j/J/PGDN:Down | k/K/PGUP:Up ");
+    if (COLS >= 85)
+        mvprintw(LINES - 2, 0, " q/<- : Close | ENTER/-> : Open | o : Open Browser | j/J/PGDN : Down | k/K/PGUP : Up ");
     else
-        mvprintw(LINES - 2, 0, " q | ENTER | o | j/J/PGDN | k/K/PGUP ");
+        mvprintw(LINES - 2, 0, "q/←|↵/→|o|j/J/PGDN/↑|k/K/PGUP/↓");
+
     attroff(A_REVERSE);
 }
 

--- a/src/application/ApplicationWindow.cpp
+++ b/src/application/ApplicationWindow.cpp
@@ -57,8 +57,8 @@ void ApplicationWindow::_printWindow()
  */
 void ApplicationWindow::_printPad()
 {
-    prefresh(this->pad, this->offsetTop, 0, 
-        this->y+1, this->x+2, this->height, COLS);
+    prefresh(this->pad, this->offsetTop, 0,
+        this->y+1, this->x+1, this->height+this->y-2, this->width+this->x);
 }
 
 /**
@@ -115,7 +115,6 @@ void ApplicationWindow::show()
 
     this->_printWindow();
     this->_printContent();
-    this->_printPad();
 }
 
 /**


### PR DESCRIPTION
# Commits in order 

- Added R, PGUP, PGDN; Fixed resize height
- Add keybinding for RIGHT and LEFT
- try unicode key-line
- fix prefresh height
- define RESIZE_LIMIT

# Changes

## Make Layout reflow

Layout now reflows to a vertical orientation if COLS < REFLOW_LIMIT.
For this,

1. Each window has its own height along with its width
2. Dimensions and positions are set according to orientation
3. prefresh call is changed to accommodate for placement in other locations
4. date not displayed in feed view on small screens

## QoL changes for Termux

### Additional Keybindings

Termux by default displays the PGDN and PGUP keys along with <- and -> keys.
Keybindings are added to facilitate easier navigation in termux without a keyboard.

Ideally, these keys should be configurable as according to #18, but a quick fix for now as I do not know enough about the config system to make requisite changes.

### Unicode Control hints

In order to reduce width of the control hints, Unicode symbols are used which reduce the space needed. This may however break on ncurses without unicode support.

## Added KEY\_R binding

Some ncurses versions/compilations do not implement the `resize` signal, and hence the screen will not refresh as expected. Keybinding R is added to perform a force refresh.


